### PR TITLE
Code cleanup and minor optimization

### DIFF
--- a/Main.cs
+++ b/Main.cs
@@ -48,8 +48,6 @@ namespace AltNetIk
         private static PacketData senderPacketData = new PacketData();
         private static ParamData senderParamData = new ParamData();
 
-        private static List<string> boneNames = new List<string>();
-
         public static string color(string c, string s)
         { return $"<color={c}>{s}</color>"; } // stolen from MintLily
 
@@ -112,7 +110,6 @@ namespace AltNetIk
 
             _streamSafe = Environment.GetCommandLineArgs().Contains("-streamsafe");
             ReMod_Core_Downloader.LoadReModCore();
-            boneNames = HumanTrait.BoneName.ToList();
 
             netPacketProcessor.RegisterNestedType<PacketData.Quaternion>();
             netPacketProcessor.RegisterNestedType<PacketData.Vector3>();

--- a/Receiver.cs
+++ b/Receiver.cs
@@ -161,7 +161,7 @@ namespace AltNetIk
                     deltaFloat = 1.0f;
 
                 int index = -1;
-                for (int i = 0; i < 55; i++)
+                for (int i = 0; i < HumanTrait.BoneCount; i++)
                 {
                     if (!boneData.boneList[i])
                         continue;

--- a/Sender.cs
+++ b/Sender.cs
@@ -24,9 +24,9 @@ namespace AltNetIk
             netRotations = new PacketData.Quaternion[senderPlayerData.boneCount];
 
             int index = -1;
-            for (int i = 0; i < 55; i++)
+            foreach (bool bone in senderPlayerData.boneList)
             {
-                if (!senderPlayerData.boneList[i])
+                if (!bone)
                     continue;
                 index++;
 
@@ -112,7 +112,7 @@ namespace AltNetIk
             NetDataWriter writer = new NetDataWriter();
             EventData eventData = new EventData
             {
-                version = short.Parse(BuildInfo.Version.Substring(0, BuildInfo.Version.LastIndexOf(".")).Replace(".", "")),
+                version = short.Parse(BuildInfo.Version.Substring(0, BuildInfo.Version.LastIndexOf('.')).Replace(".", "")),
                 lobbyHash = currentInstanceIdHash,
                 photonId = currentPhotonId,
                 eventName = "LocationUpdate"
@@ -129,7 +129,7 @@ namespace AltNetIk
             NetDataWriter writer = new NetDataWriter();
             EventData eventData = new EventData
             {
-                version = short.Parse(BuildInfo.Version.Substring(0, BuildInfo.Version.LastIndexOf(".")).Replace(".", "")),
+                version = short.Parse(BuildInfo.Version.Substring(0, BuildInfo.Version.LastIndexOf('.')).Replace(".", "")),
                 lobbyHash = currentInstanceIdHash,
                 photonId = currentPhotonId,
                 eventName = "PlayerDisconnect"

--- a/SetupBones.cs
+++ b/SetupBones.cs
@@ -13,7 +13,7 @@ namespace AltNetIk
         {
             int photonId = player.prop_PhotonView_0.field_Private_Int32_0;
             int boneCount = 0;
-            bool[] boneList = new bool[55];
+            bool[] boneList = new bool[HumanTrait.BoneCount];
 
             var avatarParams = avatarManager.field_Private_AvatarPlayableController_0?.field_Private_Dictionary_2_Int32_AvatarParameter_0;
             var parameters = new Dictionary<string, AvatarParameter>();
@@ -81,13 +81,13 @@ namespace AltNetIk
             }
 
             var avatar = animator.avatar;
-            var hd = avatar.humanDescription;
-            var human = hd.human;
-            for (int i = 0; i < human.Length; i++)
+            foreach (HumanBone humanBone in avatar.humanDescription.human)
             {
-                HumanBone humanBone = human[i];
-                int boneIndex = boneNames.FindIndex(a => string.Equals(a, humanBone.humanName));
-                if (boneIndex < 0 || humanBone.humanName == "LeftEye" || humanBone.humanName == "RightEye")
+                if (humanBone.humanName.EndsWith("Eye"))
+                    continue;
+
+                int boneIndex = HumanTrait.BoneName.IndexOf(humanBone.humanName);
+                if (boneIndex < 0)
                     continue;
 
                 boneCount++;
@@ -97,7 +97,7 @@ namespace AltNetIk
             {
                 // legacy fallback
                 int bodyBoneIndex = -1;
-                for (int i = 0; i < 55; i++)
+                for (int i = 0; i < HumanTrait.BoneCount; i++)
                 {
                     HumanBodyBones bodyBone = (HumanBodyBones)i;
                     Transform bone = animator.GetBoneTransform(bodyBone);
@@ -133,7 +133,7 @@ namespace AltNetIk
             };
 
             int index = -1;
-            for (int i = 0; i < 55; i++)
+            for (int i = 0; i < HumanTrait.BoneCount; i++)
             {
                 if (!boneList[i])
                     continue;
@@ -162,7 +162,7 @@ namespace AltNetIk
         {
             int photonId = player.prop_PhotonView_0.field_Private_Int32_0;
             int boneCount = 0;
-            bool[] boneList = new bool[55];
+            bool[] boneList = new bool[HumanTrait.BoneCount];
 
             var avatarParams = avatarManager.field_Private_AvatarPlayableController_0?.field_Private_Dictionary_2_Int32_AvatarParameter_0;
             var parameters = new Dictionary<string, AvatarParameter>();
@@ -235,13 +235,15 @@ namespace AltNetIk
             }
 
             var avatar = animator.avatar;
-            var hd = avatar.humanDescription;
-            var human = hd.human;
-            for (int i = 0; i < human.Length; i++)
+            foreach (HumanBone humanBone in avatar.humanDescription.human)
             {
-                HumanBone humanBone = human[i];
-                int boneIndex = boneNames.FindIndex(a => string.Equals(a, humanBone.humanName));
-                if (boneIndex < 0 || humanBone.humanName == "LeftEye" || humanBone.humanName == "RightEye")
+                string boneName = humanBone.humanName;
+
+                if (boneName.EndsWith("Eye"))
+                    continue;
+
+                int boneIndex = HumanTrait.BoneName.IndexOf(boneName);
+                if (boneIndex < 0)
                     continue;
 
                 boneCount++;
@@ -251,11 +253,14 @@ namespace AltNetIk
             {
                 // legacy fallback
                 int bodyBoneIndex = -1;
-                for (int i = 0; i < 55; i++)
+                for (int i = 0; i < HumanTrait.BoneCount; i++)
                 {
+                    if (i == (int)HumanBodyBones.LeftEye || i == (int)HumanBodyBones.RightEye)
+                        continue;
+
                     HumanBodyBones bodyBone = (HumanBodyBones)i;
                     Transform bone = animator.GetBoneTransform(bodyBone);
-                    if (bone == null || i == (int)HumanBodyBones.LeftEye || i == (int)HumanBodyBones.RightEye)
+                    if (bone == null)
                         continue;
 
                     bodyBoneIndex++;
@@ -281,7 +286,7 @@ namespace AltNetIk
             };
 
             int index = -1;
-            for (int i = 0; i < 55; i++)
+            for (int i = 0; i < HumanTrait.BoneCount; i++)
             {
                 if (!boneList[i])
                     continue;


### PR DESCRIPTION
Made the code a little more readable:
- Removed copy of bonenames and instead access the HumanTrait's directly
- Actually use HumanTrait.BoneCount instead of having the number 55 scattered troughout the sourcecode

Did some minor optimization like:
- Skipping searching trough lists if theres no need to
- Find index by char instead of string
- Match "LeftEye" and "RightEye" by "Eye" at end instead of doing two seperate string comparisons
- Use foreach instead of accessing by index where its not needed